### PR TITLE
Generalized DecimalNumber syntax

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -357,7 +357,7 @@ BooleanLiteral
   : 'true' | 'false' ;
 
 DecimalNumber
-  : [0-9]+ ;
+  : [0-9]+ ( '.' [0-9]+ )? ( 'e' [0-9]+ )? ;
 
 HexNumber
   : '0x' HexCharacter+ ;


### PR DESCRIPTION
 To possibly have decimal point and exponent. See, for example [Line 499 of this code](https://github.com/merlox/pally-bounty/blob/91a0af777a8acca9cc55b7742ea6d8b8a0562f28/Crowdsale.sol#L499).