### PR TITLE
Make tuple components optional

### DIFF
--- a/Solidity.g4
+++ b/Solidity.g4
@@ -338,7 +338,7 @@ linkerSymbol
   : 'linkerSymbol' '(' StringLiteral ')' ;
 
 tupleExpression
-  : '(' ( expression ( ',' expression )* )? ')'
+  : '(' ( expression? ( ',' expression? )* ) ')'
   | '[' ( expression ( ',' expression )* )? ']' ;
 
 elementaryTypeNameExpression

--- a/test.sol
+++ b/test.sol
@@ -498,3 +498,12 @@ contract test {
     uint256 a = 2.3e5;
   }
 }
+
+contract test {
+  function f() {
+    uint256 a;
+    (a,) = g();
+    (,) = g();
+    () = ();
+  }
+}


### PR DESCRIPTION
Allows to parse, e.g.
```
uint a;
(a,) = foo();
```

Corresponding update to Solidity docs in ethereum/solidity#3204.